### PR TITLE
Updates google_sign_in dependency to version 6.1.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   google_fonts: ^6.1.0
-  google_sign_in: ^6.1.0
+  google_sign_in: ^6.1.1  # For Google Sign-In
   firebase_core: ^2.30.0
   firebase_auth: ^4.17.4
   cloud_firestore: ^4.15.6


### PR DESCRIPTION
Upgrades the google_sign_in package from version 6.1.0 to 6.1.1 to ensure compatibility with the latest features and bug fixes.

No functional changes are introduced.

Fixes #789